### PR TITLE
check to convert ras/decs to numpy arrays beforecalling the beam

### DIFF
--- a/mwa_pb_lookup/lookup_beam.py
+++ b/mwa_pb_lookup/lookup_beam.py
@@ -165,6 +165,11 @@ def beam_lookup_1d(ras, decs, gridnum, time, freq):
 
     df = File(PB_FILE, "r")
 
+    if not isinstance(ras, np.ndarray):
+        ras = np.array(ras)
+    if not isinstance(decs, np.ndarray):
+        decs = np.array(decs)
+
     low_index, weight1 = mhz_to_index_weight(df["chans"][...], freq / 1_000_000)
     weights = np.array((weight1, 1 - weight1))
     beams = get_avg_beam_spline(df, gridnum, low_index, N_POL, weights)

--- a/mwa_pb_lookup/lookup_jones.py
+++ b/mwa_pb_lookup/lookup_jones.py
@@ -83,6 +83,11 @@ def jones_lookup_1d(ras, decs, gridnum, time, freq):
 
     df = File(PB_FILE, "r")
 
+    if not isinstance(ras, np.ndarray):
+        ras = np.array(ras)
+    if not isinstance(decs, np.ndarray):
+        decs = np.array(decs)
+
     low_index, weight1 = mhz_to_index_weight(df["chans"][...], freq / 1_000_000)
     weights = np.array((weight1, 1 - weight1))
     # beams = get_avg_beam_spline(df, gridnum, low_index, N_POL, weights)


### PR DESCRIPTION
It was pointed out to me that when a pair of floats are passed into the beam / jones lookup functions that they do not carry a `.shape` property, and will cause the interpolation function to fail when called. 

This change will wrap the ra and decs in a numpy array if they are not already a `numpy.ndarray` instance. 